### PR TITLE
Exclude actuator endpoints from authentication so that we can access health stats about the application.

### DIFF
--- a/src/main/java/com/hubformath/mathhubservice/config/WebSecurityConfig.java
+++ b/src/main/java/com/hubformath/mathhubservice/config/WebSecurityConfig.java
@@ -69,7 +69,7 @@ public class WebSecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http.csrf(AbstractHttpConfigurer::disable)
                    .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                   .authorizeHttpRequests(auth -> auth.requestMatchers("/api/v1/auth/**", "/error")
+                   .authorizeHttpRequests(auth -> auth.requestMatchers("/api/v1/auth/**", "/actuator/**", "/error")
                                                       .permitAll()
                                                       .anyRequest()
                                                       .authenticated())


### PR DESCRIPTION
Exclude actuator endpoints from authentication so that we can access health stats about the application.